### PR TITLE
Update Pass Without Trace to modify mod not value

### DIFF
--- a/ThandulsTogglableEffects/scripts/effects.js
+++ b/ThandulsTogglableEffects/scripts/effects.js
@@ -218,7 +218,7 @@ class ThandulBuffsAndEffects {
             icon: "modules/ThandulsTogglableEffects/media/pass-without-trace.jpg",
             duration: getDurationData(60),
             changes: [
-                {key: "data.skills.ste.value", mode: 2, value: "10"},
+                {key: "data.skills.ste.mod", mode: 2, value: "10"},
               ],
         };
     }


### PR DESCRIPTION
changed from data.skills.ste.value to data.skills.ste.mod because data.skills.ste.value only lets you set proficiency, not add bonuses.

![image](https://user-images.githubusercontent.com/38708687/106190092-2aae4a80-6177-11eb-87b6-80667d9c3cd3.png)
